### PR TITLE
[HIP] Optimized the spread kernel

### DIFF
--- a/src/gromacs/ewald/pme_gather.hip.cpp
+++ b/src/gromacs/ewald/pme_gather.hip.cpp
@@ -361,7 +361,7 @@ __launch_bounds__(c_gatherMaxThreadsPerBlock, c_gatherMinBlocksPerMP) __global__
             atomX.y    = kernelParams.atoms.d_coordinates[atomIndexGlobal * DIM + YY];
             atomX.z    = kernelParams.atoms.d_coordinates[atomIndexGlobal * DIM + ZZ];
         }
-        calculate_splines<order, atomsPerBlock, atomsPerWarp, true, false>(
+        calculate_splines<order, atomsPerBlock, atomsPerWarp, true, false, useOrderThreads>(
                 kernelParams, atomIndexOffset, atomX, atomCharge, sm_theta, sm_dtheta, sm_gridlineIndices);
 //        __syncwarp();
         __all(1);

--- a/src/gromacs/ewald/pme_spread.hip.cpp
+++ b/src/gromacs/ewald/pme_spread.hip.cpp
@@ -133,7 +133,7 @@ __device__ __forceinline__ void spread_charges(const PmeGpuHipKernelParams kerne
             const int splineIndexY = getSplineParamIndex<order, atomsPerWarp>(splineIndexBase, YY, ithy);
             float       thetaY = sm_theta[splineIndexY];
             const float Val    = thetaZ * thetaY * (*atomCharge);
-            assert(isfinite(Val));
+            //assert(isfinite(Val));
             const int offset = iy * pnz + iz;
 
 #pragma unroll
@@ -148,8 +148,8 @@ __device__ __forceinline__ void spread_charges(const PmeGpuHipKernelParams kerne
                 const int splineIndexX =
                         getSplineParamIndex<order, atomsPerWarp>(splineIndexBase, XX, ithx);
                 const float thetaX = sm_theta[splineIndexX];
-                assert(isfinite(thetaX));
-                assert(isfinite(gm_grid[gridIndexGlobal]));
+                //assert(isfinite(thetaX));
+                //assert(isfinite(gm_grid[gridIndexGlobal]));
 #if (HIP_VERSION_MAJOR >= 3) && (HIP_VERSION_MINOR > 3)
                 atomicAddNoRet(gm_grid + gridIndexGlobal, thetaX * Val);
 #else
@@ -254,7 +254,7 @@ __launch_bounds__(c_spreadMaxThreadsPerBlock) CLANG_DISABLE_OPTIMIZATION_ATTRIBU
             atomX.y = kernelParams.atoms.d_coordinates[atomIndexGlobal * DIM + YY];
             atomX.z = kernelParams.atoms.d_coordinates[atomIndexGlobal * DIM + ZZ];
         }
-        calculate_splines<order, atomsPerBlock, atomsPerWarp, false, writeGlobal>(
+        calculate_splines<order, atomsPerBlock, atomsPerWarp, false, writeGlobal, useOrderThreads>(
                 kernelParams, atomIndexOffset, atomX, atomCharge, sm_theta, &dtheta, sm_gridlineIndices);
 //        __syncwarp();
         __all(1);


### PR DESCRIPTION
Do some optimization on the spread kernel
1. take off assert function call
Regard as the assert api will impact the performance, we submit a jira to ask compiler team
http://ontrack-internal.amd.com/browse/SWDEV-237312?filter=-2

2. Increase parallelism on the calculate_splines function 