### PR TITLE
Revert "Optimise PME gather and spread kernel for HIP"

### DIFF
--- a/src/gromacs/ewald/pme_gpu_constants.h
+++ b/src/gromacs/ewald/pme_gpu_constants.h
@@ -138,14 +138,10 @@ enum class ThreadsPerAtom : int
  */
 
 //! Spreading max block width in warps picked among powers of 2 (2, 4, 8, 16) for max. occupancy and min. runtime in most cases
-#ifdef GMX_NAVI_BUILD
+#if GMX_NAVI_BUILD
 constexpr int c_spreadMaxWarpsPerBlock = 8;
 #else
-#if GMX_GPU_HIP
-constexpr int c_spreadMaxWarpsPerBlock = 2;
-#else
 constexpr int c_spreadMaxWarpsPerBlock = 4;
-#endif
 #endif
 
 //! Solving kernel max block width in warps picked among powers of 2 (2, 4, 8, 16) for max.

--- a/src/gromacs/ewald/pme_spread.hip.cpp
+++ b/src/gromacs/ewald/pme_spread.hip.cpp
@@ -156,8 +156,8 @@ __device__ __forceinline__ void spread_charges(const PmeGpuCudaKernelParams kern
                         getSplineParamIndex<order, atomsPerWarp>(splineIndexBase, XX, ithx);
                 const float thetaX = sm_theta[splineIndexX];
                 assert(isfinite(thetaX));
-                assert(isfinite(*reinterpret_cast<float*>(reinterpret_cast<char*>(gm_grid) + (gridIndexGlobal * static_cast<unsigned int>(sizeof(float))))));
-                atomicAdd(reinterpret_cast<float*>(reinterpret_cast<char*>(gm_grid) + (gridIndexGlobal * static_cast<unsigned int>(sizeof(float)))), thetaX * Val);
+                assert(isfinite(gm_grid[gridIndexGlobal]));
+                atomicAddNoRet(gm_grid + gridIndexGlobal, thetaX * Val);
             }
         }
     }
@@ -185,10 +185,10 @@ template<int order, bool computeSplines, bool spreadCharges, bool wrapX, bool wr
 LAUNCH_BOUNDS_EXACT_SINGLE(c_spreadMaxThreadsPerBlock) CLANG_DISABLE_OPTIMIZATION_ATTRIBUTE __global__
         void pme_spline_and_spread_kernel(const PmeGpuCudaKernelParams kernelParams)
 {
-    constexpr int threadsPerAtomValue = (threadsPerAtom == ThreadsPerAtom::Order) ? order : order * order;
-    constexpr int atomsPerBlock       = c_spreadMaxThreadsPerBlock / threadsPerAtomValue;
+    const int threadsPerAtomValue = (threadsPerAtom == ThreadsPerAtom::Order) ? order : order * order;
+    const int atomsPerBlock       = c_spreadMaxThreadsPerBlock / threadsPerAtomValue;
     // Number of atoms processed by a single warp in spread and gather
-    constexpr int atomsPerWarp = warpSize/ threadsPerAtomValue;
+    const int atomsPerWarp = warpSize/ threadsPerAtomValue;
     // Gridline indices, ivec
     __shared__ int sm_gridlineIndices[atomsPerBlock * DIM];
     // Charges
@@ -224,13 +224,36 @@ LAUNCH_BOUNDS_EXACT_SINGLE(c_spreadMaxThreadsPerBlock) CLANG_DISABLE_OPTIMIZATIO
         return;
     }
     /* Charges, required for both spline and spread */
-    atomCharge = kernelParams.atoms.d_coefficients[0][atomIndexGlobal];
+    if (c_useAtomDataPrefetch)
+    {
+        pme_gpu_stage_atom_data<float, atomsPerBlock, 1>(
+                sm_coefficients, &kernelParams.atoms.d_coefficients[0][kernelParams.pipelineAtomStart]);
+        __syncthreads();
+        atomCharge = sm_coefficients[atomIndexLocal];
+    }
+    else
+    {
+        atomCharge = kernelParams.atoms.d_coefficients[0][atomIndexGlobal];
+    }
 
     if (computeSplines)
     {
         const float3* __restrict__ gm_coordinates =
                 asFloat3(&kernelParams.atoms.d_coordinates[kernelParams.pipelineAtomStart]);
-        atomX = gm_coordinates[atomIndexGlobal];
+        if (c_useAtomDataPrefetch)
+        {
+            // Coordinates
+            __shared__ float3 sm_coordinates[atomsPerBlock];
+
+            /* Staging coordinates */
+            pme_gpu_stage_atom_data<float3, atomsPerBlock, 1>(sm_coordinates, gm_coordinates);
+            __syncthreads();
+            atomX = sm_coordinates[atomIndexLocal];
+        }
+        else
+        {
+            atomX = gm_coordinates[atomIndexGlobal];
+        }
         calculate_splines<order, atomsPerBlock, atomsPerWarp, false, writeGlobal, numGrids>(
                 kernelParams, atomIndexOffset, atomX, atomCharge, sm_theta, &dtheta, sm_gridlineIndices);
         // __syncwarp();
@@ -264,7 +287,17 @@ LAUNCH_BOUNDS_EXACT_SINGLE(c_spreadMaxThreadsPerBlock) CLANG_DISABLE_OPTIMIZATIO
     if (numGrids == 2)
     {
         __syncthreads();
-        atomCharge = kernelParams.atoms.d_coefficients[1][atomIndexGlobal];
+        if (c_useAtomDataPrefetch)
+        {
+            pme_gpu_stage_atom_data<float, atomsPerBlock, 1>(sm_coefficients,
+                                                             kernelParams.atoms.d_coefficients[1]);
+            __syncthreads();
+            atomCharge = sm_coefficients[atomIndexLocal];
+        }
+        else
+        {
+            atomCharge = kernelParams.atoms.d_coefficients[1][atomIndexGlobal];
+        }
         if (spreadCharges && atomIndexGlobal < kernelParams.atoms.nAtoms)
         {
             if (!kernelParams.usePipeline || (atomIndexGlobal < kernelParams.pipelineAtomEnd))

--- a/src/gromacs/gpu_utils/hip_kernel_utils.hpp
+++ b/src/gromacs/gpu_utils/hip_kernel_utils.hpp
@@ -92,8 +92,7 @@ static __forceinline__ __device__ T fetchFromParamLookupTable(const T*          
     T result;
 #if DISABLE_HIP_TEXTURES
     GMX_UNUSED_VALUE(texObj);
-    result = *reinterpret_cast<const T*>(reinterpret_cast<const char*>(d_ptr) + index * static_cast<unsigned int>(sizeof(T)));
-    //result = LDG(d_ptr + index);
+    result = LDG(d_ptr + index);
 #else
     GMX_UNUSED_VALUE(d_ptr);
     result = fetchFromTexture<T>(texObj, index);


### PR DESCRIPTION
Reverting this commit for now. It seems like it introduces an error to the Coulomb reciprocal energy term at time step zero, which means it is probably breaking PME somehow.

@AJcodes  would you mind reviewing this commit and submitting it again?