### PR TITLE
Placing last arguments on do_force on the same line

### DIFF
--- a/src/gromacs/mdrun/md.cpp
+++ b/src/gromacs/mdrun/md.cpp
@@ -1198,9 +1198,7 @@ void gmx::LegacySimulator::do_md()
                      ed ? ed->getLegacyED() : nullptr,
                      fr->longRangeNonbondeds.get(),
                      (bNS ? GMX_FORCE_NS : 0) | force_flags,
-                     ddBalanceRegionHandler,
-                     &realGridSize,  
-                     &d_grid);
+                     ddBalanceRegionHandler, &realGridSize, &d_grid);
         }
 
         // VV integrators do not need the following velocity half step


### PR DESCRIPTION
Seems like plumed relies on lineinfo to patch the code, so I'm folding the last two lines into the previous one. 