### PR TITLE
Slightly increase replica exchange test tolerance

### DIFF
--- a/src/programs/mdrun/tests/replicaexchange_equivalence.cpp
+++ b/src/programs/mdrun/tests/replicaexchange_equivalence.cpp
@@ -191,7 +191,7 @@ TEST_P(ReplicaExchangeTest, Works)
         {
             energyTermsToCompare.emplace(
                     interaction_function[F_ECONSERVED].longname,
-                    relativeToleranceAsPrecisionDependentUlp(50.0, 100, doubleTolerance));
+                    relativeToleranceAsPrecisionDependentUlp(50.0, 500, doubleTolerance));
         }
         if (pcoupl != PressureCoupling::No)
         {


### PR DESCRIPTION
There has been an issue with just slightly missing the target floating point tolerance.